### PR TITLE
GH-127: add mime type check for image upload

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -141,7 +141,7 @@
                   <i class="file image icon" aria-hidden="true"></i>
                   Import picture
               </button>
-              <input type="file" id="qrfile" style="display: none;" accept="image/*">
+              <input type="file" id="qrfile" style="display: none;" accept="image/jpeg, image/png">
             </section>
             <section id="scan" class="hide six wide column page">
                 <div class="ui fluid card">

--- a/src/index.js
+++ b/src/index.js
@@ -302,7 +302,7 @@ window.addEventListener('load', function() {
       return;
     }
 
-    if (['image/jpg', 'image/jpeg', 'image/png'].includes(file.type)) {
+    if (['image/jpeg', 'image/png'].includes(file.type)) {
       QrScanner.scanImage(file)
       .then(result => decode(result))
       .catch((error) => {

--- a/src/index.js
+++ b/src/index.js
@@ -294,20 +294,25 @@ window.addEventListener('load', function() {
 
   $('#scanAnother').on('click', () => {
     navigateTo('scan');
-  })
+  });
 
   $('#qrfile').on('change', (e) => {
     const file = e.target.files[0]
     if (!file) {
       return;
     }
-    QrScanner.scanImage(file)
+
+    if (['image/jpg', 'image/jpeg', 'image/png'].includes(file.type)) {
+      QrScanner.scanImage(file)
       .then(result => decode(result))
       .catch((error) => {
         console.error("Error while decoding QR code", error);
         window.alert("No QR code found in image");
-      })
-  })
+      });
+    } else {
+      window.alert('Image type not supported. Try again with a valid JPG, JPEG, or PNG image');
+    }
+  });
 
   function initScanner() {
     QrScanner.WORKER_PATH = "/qr-scanner-worker.min.js";


### PR DESCRIPTION
Adds a simple mime type check and restricts image upload to JPG, JPEG, and PNG (file extension check really).

Would this be sufficient as a fix? Alternatively, could look into another solution: determining the image type by inspecting and comparing the first few bytes to known jpg/jpeg/png file signatures (Magic Bytes).