### PR TITLE
Fix for "Safari cannot download this file" error for Covid Recovery Certificate

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -652,7 +652,7 @@ window.addEventListener('load', function() {
           newPassbookItem(template, "auxiliaryFields", "valid-from", "Valid from", formatDate(certificateContent.df), "PKDateStyleShort");
           // Certificate valid until
           newPassbookItem(template, "auxiliaryFields", "valid-until", "Valid until", formatDate(certificateContent.du), "PKDateStyleShort");
-          template.expirationDate = formatDate(certificateContent.du, true) + "Z";
+          template.expirationDate = formatDate(certificateContent.du, true);
         });
 
       } else {


### PR DESCRIPTION
Fix for incorrect date format when generating a Covid-19 COVID-19 Recovery Certificate expiration date which would render the pass invalid on iOS.
Attempting to fix #308 #307 #298 #285 